### PR TITLE
Add fallback for local socket address

### DIFF
--- a/app/src/main/java/com/winlator/winhandler/WinHandler.java
+++ b/app/src/main/java/com/winlator/winhandler/WinHandler.java
@@ -254,7 +254,11 @@ public class WinHandler {
         try {
             localhost = InetAddress.getLocalHost();
         }
-        catch (UnknownHostException e) {}
+        catch (UnknownHostException e) {
+            try {
+                localhost = InetAddress.getByName("127.0.0.1");
+            } catch (UnknownHostException ex) {}
+        }
 
         running = true;
         startSendThread();


### PR DESCRIPTION
Same problem and same solution as https://github.com/brunodev85/winlator/pull/48

To be more clear: getLocalHost might fail (as it does on my device, where I have a nethunter chroot which sets kali as hostname and getLocalHost can't resolve it) getLoopbackAddress would be a more elegant solution if it would get the loopback ipv4, but it might return an ipv6 (again, in my case it does) which doesn't actually connect to the server