### PR TITLE
Allow gamepad selection to work from persisted bindings

### DIFF
--- a/app/src/main/java/com/winlator/ExternalControllerBindingsActivity.java
+++ b/app/src/main/java/com/winlator/ExternalControllerBindingsActivity.java
@@ -218,7 +218,7 @@ public class ExternalControllerBindingsActivity extends AppCompatActivity {
                 @Override
                 public void onNothingSelected(AdapterView<?> parent) {}
             });
-            holder.bindingType.setSelection(item.getBinding().isKeyboard() ? 0 : 1, false);
+            holder.bindingType.setSelection(item.getBinding().isKeyboard() ? 0 : item.getBinding().isMouse() : 1 ? 2, false);
 
             holder.binding.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
                 @Override


### PR DESCRIPTION
This fixes the issue that adding gamepad settings for external controller mappings  revert to mouse on load/scroll