### PR TITLE
 Fix: Handle Spaces in Environment Variable Names and Values

### DIFF
--- a/app/src/main/java/com/winlator/ContainerDetailFragment.java
+++ b/app/src/main/java/com/winlator/ContainerDetailFragment.java
@@ -387,7 +387,7 @@ public class ContainerDetailFragment extends Fragment {
         for (int i = 0; i < parent.getChildCount(); i++) {
             View child = parent.getChildAt(i);
             String name = ((TextView)child.findViewById(R.id.TextView)).getText().toString();
-            String value = ((EditText)child.findViewById(R.id.EditText)).getText().toString().trim();
+            String value = ((EditText)child.findViewById(R.id.EditText)).getText().toString().trim().replace(" ", "");
             if (!value.isEmpty()) envVars.put(name, value);
         }
         return envVars.toString();

--- a/app/src/main/java/com/winlator/contentdialog/AddEnvVarDialog.java
+++ b/app/src/main/java/com/winlator/contentdialog/AddEnvVarDialog.java
@@ -21,8 +21,8 @@ public class AddEnvVarDialog extends ContentDialog {
         setIcon(R.drawable.icon_env_var);
 
         setOnConfirmCallback(() -> {
-            String name = etName.getText().toString().trim();
-            String value = etValue.getText().toString().trim();
+            String name = etName.getText().toString().trim().replace(" ", "");
+            String value = etValue.getText().toString().trim().replace(" ", "");
 
             if (!name.isEmpty() && !value.isEmpty()) {
                 LinearLayout parent = container.findViewById(R.id.LLEnvVars);


### PR DESCRIPTION
#### Description
Previously, spaces in environment variable names or values caused crashes when editing or running containers due to incorrect parsing.

#### Steps to Reproduce crash
- Create new container or edit existing container.
- Add new Environment Variable or edit existing Environment variable and add space between two words.
- save it and try to run or edit container.

#### Fix
- Updated the `ContainerDetailFragment` class and `AddEnvVarDialog` class to replace spaces with empty string.
- This change ensures proper handling of spaces in environment variable names and values.

Please review and merge. Thanks!
