### PR TITLE
Fix Shortcuts crash

### DIFF
--- a/app/src/main/java/com/winlator/container/Shortcut.java
+++ b/app/src/main/java/com/winlator/container/Shortcut.java
@@ -36,9 +36,10 @@ public class Shortcut {
 
         int index;
         for (String line : FileUtils.readLines(file)) {
-            index = line.indexOf("[");
-            if (index != -1) {
-                section = line.substring(index+1, line.indexOf("]", index));
+            line = line.trim();
+            if (line.isEmpty() || line.startsWith("#")) continue; // Skip empty lines and comments
+            if (line.startsWith("[")) {
+                section = line.substring(1, line.indexOf("]"));
             }
             else {
                 index = line.indexOf("=");


### PR DESCRIPTION
Fixes a crash in the application related to parsing `.desktop` files.

The crash occurred due to improper handling of lines containing `[` characters outside of valid section headers. 
If a file path contained `[`, it was incorrectly interpreted as a section header, leading to an empty path and subsequent errors.

Updated the parsing logic to check if a line starts with `[` to determine if it's a valid section header.
Ensured that lines with `[` characters in file paths are correctly parsed as data rather than section headers.