### PR TITLE
Add trigger mode config for external game controller

### DIFF
--- a/app/src/main/java/com/winlator/SettingsFragment.java
+++ b/app/src/main/java/com/winlator/SettingsFragment.java
@@ -13,6 +13,8 @@ import android.widget.ArrayAdapter;
 import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.LinearLayout;
+import android.widget.RadioButton;
+import android.widget.RadioGroup;
 import android.widget.SeekBar;
 import android.widget.Spinner;
 import android.widget.TextView;
@@ -135,6 +137,14 @@ public class SettingsFragment extends Fragment {
         });
         sbCursorSpeed.setProgress((int)(preferences.getFloat("cursor_speed", 1.0f) * 100));
 
+        final RadioGroup rgTriggerMode = view.findViewById(R.id.RGTriggerMode);
+        List<Integer> triggerRbIds = List.of(R.id.RBTriggerAsButton, R.id.RBTriggerAsAxis, R.id.RBTriggerAsBoth);
+        int triggerMode = preferences.getInt("trigger_mode", 2);
+
+        if (triggerMode >= 0 && triggerMode < triggerRbIds.size()) {
+            ((RadioButton) (rgTriggerMode.findViewById(triggerRbIds.get(triggerMode)))).setChecked(true);
+        }
+
         loadInstalledWineList(view);
 
         view.findViewById(R.id.BTSelectWineFile).setOnClickListener((v) -> {
@@ -151,6 +161,7 @@ public class SettingsFragment extends Fragment {
             editor.putFloat("cursor_speed", sbCursorSpeed.getProgress() / 100.0f);
             editor.putBoolean("enable_wine_debug", cbEnableWineDebug.isChecked());
             editor.putBoolean("enable_box86_64_logs", cbEnableBox86_64Logs.isChecked());
+            editor.putInt("trigger_mode", triggerRbIds.indexOf(rgTriggerMode.getCheckedRadioButtonId()));
 
             if (!wineDebugChannels.isEmpty()) {
                 editor.putString("wine_debug_channels", String.join(",", wineDebugChannels));

--- a/app/src/main/java/com/winlator/inputcontrols/ExternalController.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ExternalController.java
@@ -25,9 +25,13 @@ public class ExternalController {
     public static final byte IDX_BUTTON_R3 = 9;
     public static final byte IDX_BUTTON_L2 = 10;
     public static final byte IDX_BUTTON_R2 = 11;
+    public static final byte TRIGGER_AS_BUTTON = 0;
+    public static final byte TRIGGER_AS_AXIS = 1;
+    public static final byte TRIGGER_AS_BOTH = 2;
     private String name;
     private String id;
     private int deviceId = -1;
+    private byte triggerMode = TRIGGER_AS_BOTH;
     private final ArrayList<ExternalControllerBinding> controllerBindings = new ArrayList<>();
     public final GamepadState state = new GamepadState();
 
@@ -45,6 +49,14 @@ public class ExternalController {
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    public byte getTriggerMode() {
+        return triggerMode;
+    }
+
+    public void setTriggerMode(byte mode) {
+        triggerMode = mode;
     }
 
     public int getDeviceId() {
@@ -142,7 +154,8 @@ public class ExternalController {
 
     public boolean updateStateFromMotionEvent(MotionEvent event) {
         if (isJoystickDevice(event)) {
-            processTriggerButton(event);
+            if (triggerMode != TRIGGER_AS_BUTTON)
+                processTriggerButton(event);
             int historySize = event.getHistorySize();
             for (int i = 0; i < historySize; i++) processJoystickInput(event, i);
             processJoystickInput(event, -1);
@@ -156,7 +169,9 @@ public class ExternalController {
         int keyCode = event.getKeyCode();
         int buttonIdx = getButtonIdxByKeyCode(keyCode);
         if (buttonIdx != -1) {
-            state.setPressed(buttonIdx, pressed);
+            if (triggerMode != TRIGGER_AS_AXIS || (buttonIdx != IDX_BUTTON_L2 && buttonIdx != IDX_BUTTON_R2)) {
+                state.setPressed(buttonIdx, pressed);
+            }
             return true;
         }
 

--- a/app/src/main/java/com/winlator/winhandler/WinHandler.java
+++ b/app/src/main/java/com/winlator/winhandler/WinHandler.java
@@ -1,7 +1,10 @@
 package com.winlator.winhandler;
 
+import android.content.SharedPreferences;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
+
+import androidx.preference.PreferenceManager;
 
 import com.winlator.XServerDisplayActivity;
 import com.winlator.core.StringUtils;
@@ -41,6 +44,8 @@ public class WinHandler {
     private byte dinputMapperType = DINPUT_MAPPER_TYPE_XINPUT;
     private final XServerDisplayActivity activity;
     private final List<Integer> gamepadClients = new CopyOnWriteArrayList<>();
+    private SharedPreferences preferences;
+    private byte triggerMode;
 
     public WinHandler(XServerDisplayActivity activity) {
         this.activity = activity;
@@ -221,6 +226,8 @@ public class WinHandler {
         switch (requestCode) {
             case RequestCodes.INIT: {
                 initReceived = true;
+                preferences = PreferenceManager.getDefaultSharedPreferences(activity.getBaseContext());
+                triggerMode = (byte) preferences.getInt("trigger_mode", ExternalController.TRIGGER_AS_BOTH);
 
                 synchronized (actions) {
                     actions.notify();
@@ -252,6 +259,8 @@ public class WinHandler {
 
                 if (!useVirtualGamepad && (currentController == null || !currentController.isConnected())) {
                     currentController = ExternalController.getController(0);
+                    assert currentController != null;
+                    currentController.setTriggerMode(triggerMode);
                 }
 
                 final boolean enabled = currentController != null || useVirtualGamepad;

--- a/app/src/main/java/com/winlator/winhandler/WinHandler.java
+++ b/app/src/main/java/com/winlator/winhandler/WinHandler.java
@@ -259,8 +259,8 @@ public class WinHandler {
 
                 if (!useVirtualGamepad && (currentController == null || !currentController.isConnected())) {
                     currentController = ExternalController.getController(0);
-                    assert currentController != null;
-                    currentController.setTriggerMode(triggerMode);
+                    if (currentController != null)
+                        currentController.setTriggerMode(triggerMode);
                 }
 
                 final boolean enabled = currentController != null || useVirtualGamepad;

--- a/app/src/main/res/layout/settings_fragment.xml
+++ b/app/src/main/res/layout/settings_fragment.xml
@@ -233,6 +233,49 @@
                     style="@style/FieldSetLabel"
                     android:text="@string/logs" />
             </FrameLayout>
+
+            <FrameLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <LinearLayout style="@style/FieldSet">
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/trigger_mode"/>
+
+                    <RadioGroup
+                        android:id="@+id/RGTriggerMode"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal">
+                        <RadioButton
+                            android:id="@+id/RBTriggerAsButton"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/as_button"/>
+
+                        <RadioButton
+                            android:id="@+id/RBTriggerAsAxis"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/as_axis"/>
+
+                        <RadioButton
+                            android:id="@+id/RBTriggerAsBoth"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/both"/>
+                    </RadioGroup>
+                </LinearLayout>
+
+                <TextView
+                    style="@style/FieldSetLabel"
+                    android:text="@string/game_controller" />
+            </FrameLayout>
         </LinearLayout>
     </ScrollView>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -225,4 +225,9 @@
     <string name="msg_warning_install_wine">Warning: Installing a new version of Wine is recommended for testing purposes only.</string>
     <string name="startup_selection">Startup Selection</string>
     <string name="wine_debug_channel">Wine Debug Channel</string>
+    <string name="game_controller">Game Controller</string>
+    <string name="as_button">As Button</string>
+    <string name="as_axis">As Axis</string>
+    <string name="both">Both</string>
+    <string name="trigger_mode">Trigger Mode</string>
 </resources>


### PR DESCRIPTION
#### **Description**
  Winlator uses `KeyEvent` and `MotionEvent` to jointly map the `L2` and `R2` triggers on game controllers. This works well for some controllers, such as the `Xbox360 Game Controller`. However, for other controllers like the `Odin2 Controller`, which have their own `dead zone` settings, this leads to inconsistencies between KeyEvent and MotionEvent. 
  For example, pressing the L2 trigger to sends L2 Down (from KeyEvent). If there is subsequent movement of the right joystick or any other event that may send a MotionEvent, Winlator reads the linear value of L2. If this value hasn't reached 1.0f, Winlator sends L2 Up (from MotionEvent). This renders the triggers on the Odin2 Controller nearly unusable.
#### **Fix**
- Add three trigger modes: `as buttons`, `as axes`, and `both`(default).
- The option is located in the `Settings`.
#### **Screenshot**
![Screenshot_1](https://github.com/user-attachments/assets/f1e1ab13-99ff-4f90-b6e4-a633ab867f7e)

These changes will be beneficial for Odin2 Controller or other game controllers that have similar issues.
  Please review and merge if everything is okay. Thank you!


