### PR TITLE
Fix screen dimming when using game controller

### DIFF
--- a/app/src/main/java/com/winlator/widget/TouchpadView.java
+++ b/app/src/main/java/com/winlator/widget/TouchpadView.java
@@ -1,6 +1,9 @@
 package com.winlator.widget;
 
 import android.content.Context;
+import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.StateListDrawable;
 import android.view.InputDevice;
 import android.view.MotionEvent;
 import android.view.View;
@@ -40,8 +43,9 @@ public class TouchpadView extends View {
         super(context);
         this.xServer = xServer;
         setLayoutParams(new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+        setBackground(createTransparentBg());
         setClickable(true);
-        setFocusable(false);
+        setFocusable(true);
         setFocusableInTouchMode(false);
         updateXform(AppUtils.getScreenWidth(), AppUtils.getScreenHeight(), xServer.screenInfo.width, xServer.screenInfo.height);
     }
@@ -352,5 +356,17 @@ public class TouchpadView extends View {
         result[0] = x - lastX;
         result[1] = y - lastY;
         return result;
+    }
+
+    private StateListDrawable createTransparentBg() {
+        StateListDrawable stateListDrawable = new StateListDrawable();
+
+        ColorDrawable focusedDrawable = new ColorDrawable(Color.TRANSPARENT);
+        ColorDrawable defaultDrawable = new ColorDrawable(Color.TRANSPARENT);
+
+        stateListDrawable.addState(new int[]{android.R.attr.state_focused}, focusedDrawable);
+        stateListDrawable.addState(new int[]{}, defaultDrawable);
+
+        return stateListDrawable;
     }
 }


### PR DESCRIPTION
#### **Description**
  When using a game controller, moving the joystick causes the screen to dim slightly. 
 This is because TouchpadView gains focus, causing its background to dim in this scenario.
#### **Fix**
- Set TouchpadView to be focusable. Otherwise, `StateListDrawable` won't take effect.
- Generated a completely transparent background for TouchpadView, unaffected by focus states.

I accidentally closed #58 earlier, and all changes are the same as it.