### PR TITLE
feat: allow the activity to start from emulators frontend (Pegasus, Daijisho, ...)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,7 +43,7 @@
         </activity>
 
         <activity android:name="com.winlator.XServerDisplayActivity"
-            android:exported="false"
+            android:exported="true"
             android:theme="@style/AppThemeFullscreen"
             android:launchMode="singleTask"
             android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|smallestScreenSize|density|navigation"

--- a/app/src/main/java/com/winlator/XServerDisplayActivity.java
+++ b/app/src/main/java/com/winlator/XServerDisplayActivity.java
@@ -110,6 +110,7 @@ public class XServerDisplayActivity extends AppCompatActivity implements Navigat
     private short taskAffinityMask = 0;
     private short taskAffinityMaskWoW64 = 0;
     private int frameRatingWindowId = -1;
+    private String externalCommand = null;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -139,7 +140,13 @@ public class XServerDisplayActivity extends AppCompatActivity implements Navigat
         String screenSize = Container.DEFAULT_SCREEN_SIZE;
         if (!isGenerateWineprefix()) {
             containerManager = new ContainerManager(this);
-            container = containerManager.getContainerById(getIntent().getIntExtra("container_id", 0));
+            Intent intent = getIntent();
+
+            externalCommand = intent.getStringExtra("command");
+            String containerIdStr = intent.getStringExtra("container_id");
+            int containerId = containerIdStr == null ? 0 : Integer.parseInt(containerIdStr);
+
+            container = containerManager.getContainerById(containerId);
             containerManager.activateContainer(container);
 
             boolean wineprefixNeedsUpdate = container.getExtra("wineprefixNeedsUpdate").equals("t");
@@ -240,6 +247,9 @@ public class XServerDisplayActivity extends AppCompatActivity implements Navigat
                 changeWineAudioDriver();
             }
             setupXEnvironment();
+            if (externalCommand != null) {
+                winHandler.exec("cmd /c \"" + externalCommand + "\"");
+            }
         });
     }
 


### PR DESCRIPTION
The goal here is to allow any emulator frontend (like [Pegasus](https://pegasus-frontend.org/), Daijisho, ...) to be able to open a game on Winlator. To do that I made the changes:

- externalCommand was added in intent parameter of XServerDisplayActivity. It is optional and, if it is not null, it will be used to start a EXE. Example: `cd /d D:/a_win/NFSU2 && SPEED2.EXE`
- container_id is now a string (and then converted to int). This is needed because pegasus always send a string.
- XServerDisplayActivity is now exported. This is needed to be able to call this activity from another app

Below we have a real example of a Pegasus metadata that is capable of running Need for Speed ​​Underground 2:

```
collection: Windows
shortname: windows
launch: am start
  -n com.winlator/.XServerDisplayActivity
  -a android.intent.action.MAIN
  -e container_id 1
  -e command "cd /d D:/a_win/NFSU2 && SPEED2.EXE"
  --activity-clear-task
  --activity-clear-top
  --activity-no-history

game: Need for Speed - Underground 2
file: dumb
assets.box_front: media/box2dfront/Need for Speed - Underground 2.png
```

and thanks to this metadata we now can have:

![WhatsApp Image 2024-11-06 at 20 38 44](https://github.com/user-attachments/assets/039d9251-7682-45e2-a9cd-f40c1b333bc9)

![WhatsApp Image 2024-11-06 at 20 38 43](https://github.com/user-attachments/assets/5e60c01d-5df0-4ce2-85e3-1d7b203bf154)

_Important note:  I opened the EXE with this type of command because it was the only one that, at least in Need for Speed ​​Underground 2, did not generate a black screen. The Winlator 8.0 code is not open source yet and so I could not analyze how you open the EXEs, but anyway, the Winlator 8 "file manager" cannot open NFSU2 without giving a black screen and closing._