### PR TITLE
Fix RedAlert2 crash

### DIFF
--- a/app/src/main/java/com/winlator/xserver/ClientOpcodes.java
+++ b/app/src/main/java/com/winlator/xserver/ClientOpcodes.java
@@ -31,6 +31,7 @@ public abstract class ClientOpcodes {
     public static final byte FREE_PIXMAP = 54;
     public static final byte CREATE_GC = 55;
     public static final byte CHANGE_GC = 56;
+    public static final byte SET_DASHES = 58;
     public static final byte SET_CLIP_RECTANGLES = 59;
     public static final byte FREE_GC = 60;
     public static final byte COPY_AREA = 62;

--- a/app/src/main/java/com/winlator/xserver/Drawable.java
+++ b/app/src/main/java/com/winlator/xserver/Drawable.java
@@ -120,13 +120,15 @@ public class Drawable extends XResource {
         if ((dstX + width) > this.width) width = (short)(this.width - dstX);
         if ((dstY + height) > this.height) height = (short)(this.height - dstY);
 
-        if (gcFunction == GraphicsContext.Function.COPY) {
-            copyArea(srcX, srcY, dstX, dstY, width, height, drawable.getStride(), this.getStride(), drawable.data, this.data);
-        }
-        else copyAreaOp(srcX, srcY, dstX, dstY, width, height, drawable.getStride(), this.getStride(), drawable.data, this.data, gcFunction.ordinal());
+        if (this.data != null && drawable.data != null) {
+            if (gcFunction == GraphicsContext.Function.COPY) {
+                copyArea(srcX, srcY, dstX, dstY, width, height, drawable.getStride(), this.getStride(), drawable.data, this.data);
+            }
+            else copyAreaOp(srcX, srcY, dstX, dstY, width, height, drawable.getStride(), this.getStride(), drawable.data, this.data, gcFunction.ordinal());
 
-        this.data.rewind();
-        drawable.data.rewind();
+            this.data.rewind();
+            drawable.data.rewind();
+        }
 
         texture.setNeedsUpdate(true);
         if (onDrawListener != null) onDrawListener.run();

--- a/app/src/main/java/com/winlator/xserver/XClientRequestHandler.java
+++ b/app/src/main/java/com/winlator/xserver/XClientRequestHandler.java
@@ -312,6 +312,9 @@ public class XClientRequestHandler implements RequestHandler {
                         GraphicsContextRequests.changeGC(client, inputStream, outputStream);
                     }
                     break;
+                case ClientOpcodes.SET_DASHES:
+                    client.skipRequest();
+                    break;
                 case ClientOpcodes.SET_CLIP_RECTANGLES:
                     client.skipRequest();
                     break;


### PR DESCRIPTION
When running RedAlert2 with Winlator, I noticed the game crashes at the game save screen.

After investigation, it was identified that the X Server didn‘t implement the SetDashes operation. By skipping this command directly, the game now runs normally.

The null-check guard I added in `Drawable.java` was due to crashes on my build - it can be removed if unnecessary.