### PR TITLE
Fix unbound ESC key on all physical keyboards.

### DIFF
--- a/app/src/main/java/com/winlator/xserver/Keyboard.java
+++ b/app/src/main/java/com/winlator/xserver/Keyboard.java
@@ -118,6 +118,7 @@ public class Keyboard {
     private static XKeycode[] createKeycodeMap() {
         XKeycode[] keycodeMap = new XKeycode[(KeyEvent.getMaxKeyCode() + 1)];
         keycodeMap[KeyEvent.KEYCODE_ENTER] = XKeycode.KEY_ENTER;
+        keycodeMap[KeyEvent.KEYCODE_ESCAPE] = XKeycode.KEY_ESC;
         keycodeMap[KeyEvent.KEYCODE_DPAD_LEFT] = XKeycode.KEY_LEFT;
         keycodeMap[KeyEvent.KEYCODE_DPAD_RIGHT] = XKeycode.KEY_RIGHT;
         keycodeMap[KeyEvent.KEYCODE_DPAD_UP] = XKeycode.KEY_UP;


### PR DESCRIPTION
If you try to use a USB or bluetooth keyboard, you currently have to bring up the overlay or use remapping software such as ATNSOFT Key Remapper or https://github.com/And42/KeyboardRemapper (which don't always work) to access the ESC key.