### PR TITLE
Added Permission for external storage

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,7 +22,8 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
-
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
+    
     <application
         android:icon="@mipmap/ic_launcher"
         android:appCategory="game"


### PR DESCRIPTION
a simple 1 liner that adds the option to read external USB drives, lets them get the storage ID and simply mount it to a drive letter inside winlator.