### PR TITLE
Shortcut export to frontend

### DIFF
--- a/app/src/main/res/menu/shortcut_popup_menu.xml
+++ b/app/src/main/res/menu/shortcut_popup_menu.xml
@@ -2,4 +2,5 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:id="@+id/shortcut_settings" android:title="@string/settings" android:icon="@drawable/icon_popup_menu_settings" android:iconTint="@color/colorAccent" />
     <item android:id="@+id/shortcut_remove" android:title="@string/remove" android:icon="@drawable/icon_popup_menu_remove" android:iconTint="@color/colorAccent" />
+    <item android:id="@+id/shortcut_export_to_frontend" android:title="@string/export_for_frontend" android:icon="@drawable/icon_popup_menu_export" android:iconTint="@color/colorAccent" />
 </menu>

--- a/app/src/main/res/menu/shortcut_popup_menu.xml
+++ b/app/src/main/res/menu/shortcut_popup_menu.xml
@@ -2,5 +2,5 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:id="@+id/shortcut_settings" android:title="@string/settings" android:icon="@drawable/icon_popup_menu_settings" android:iconTint="@color/colorAccent" />
     <item android:id="@+id/shortcut_remove" android:title="@string/remove" android:icon="@drawable/icon_popup_menu_remove" android:iconTint="@color/colorAccent" />
-    <item android:id="@+id/shortcut_export_to_frontend" android:title="@string/export_for_frontend" android:icon="@drawable/icon_popup_menu_export" android:iconTint="@color/colorAccent" />
+    <item android:id="@+id/shortcut_export_to_frontend" android:title="@string/export_for_frontend" android:icon="@drawable/icon_popup_menu_download" android:iconTint="@color/colorAccent" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -225,4 +225,5 @@
     <string name="msg_warning_install_wine">Warning: Installing a new version of Wine is recommended for testing purposes only.</string>
     <string name="startup_selection">Startup Selection</string>
     <string name="wine_debug_channel">Wine Debug Channel</string>
+    <string name="export_for_frontend">Export for frontend</string>
 </resources>


### PR DESCRIPTION
**What does this PR do?**

This attempts to add an "export to frontend" menu item to existing shortcuts in winlator so that they can be saved to the android device at the default location of `/Winlator/Frontend`

**Why?**
This appears to be in other forks of winlator and is super useful for tools like [Beacon Launcher](https://play.google.com/store/apps/details?id=com.radikal.gamelauncher) and [Daijisho](https://play.google.com/store/apps/details?id=com.magneticchen.daijishou), [ES-DE](https://es-de.org/), [DIG ](https://play.google.com/store/apps/details?id=com.digdroid.alman.dig) etc. so that you can manage and run the specific shortcuts directly from the launcher. 

**Other Notes**
- These changes I've adapted are from mostly other forks (Thanks winlator cmod!)
- I had a hard time building/testing these changes..so it needs a good review