### PR TITLE
Fix crash on unmapped key codes in onKeyEvent

### DIFF
--- a/app/src/main/java/com/winlator/xserver/Keyboard.java
+++ b/app/src/main/java/com/winlator/xserver/Keyboard.java
@@ -99,6 +99,9 @@ public class Keyboard {
         int action = event.getAction();
         if (action == KeyEvent.ACTION_DOWN || action == KeyEvent.ACTION_UP) {
             int keyCode = event.getKeyCode();
+
+            if (keyCode < 0 || keyCode >= keycodeMap.length) return false; // Ignore unmapped key codes
+ 
             XKeycode xKeycode = keycodeMap[keyCode];
             if (xKeycode == null) return false;
 


### PR DESCRIPTION
Added a check to ignore unmapped key codes in onKeyEvent method to prevent crashes.

Game Genie (on Asus devices) may send invalid keycodes such as `851` or `861` during screen on/off events. This caused `Keyboard.onKeyEvent()` to index `keys[keyCode]` out of bounds (`length=159, index=851`), leading to `ArrayIndexOutOfBoundsException`.

#### Exception details
Extracted from a _logcat_ generated with `adb`:
```
FATAL EXCEPTION: main
Process: com.winlator
java.lang.ArrayIndexOutOfBoundsException: length=159 index=851
    at com.winlator.xserver.Keyboard.onKeyEvent(Keyboard.java:104)
Caused by: android.view.KeyEvent-JNI: java.lang.IllegalArgumentException: Invalid keycode 851
```
------------
I know this code/repository is old and doesn't include all the changes from your latest releases, but this bug is still present in those releases, so I hope you can include this in the next ones.