### PR TITLE
Auto-detect GPU and select optimal graphics driver for new containers

### DIFF
--- a/app/src/main/java/com/winlator/ContainerDetailFragment.java
+++ b/app/src/main/java/com/winlator/ContainerDetailFragment.java
@@ -35,6 +35,7 @@ import com.winlator.core.AppUtils;
 import com.winlator.core.Callback;
 import com.winlator.core.EnvVars;
 import com.winlator.core.FileUtils;
+import com.winlator.core.GPUInformation;
 import com.winlator.core.KeyValueSet;
 import com.winlator.core.PreloaderDialog;
 import com.winlator.core.StringUtils;
@@ -135,8 +136,9 @@ public class ContainerDetailFragment extends Fragment {
         vDXWrapperConfig.setTag(isEditMode() ? container.getDXWrapperConfig() : "");
 
         setupDXWrapperSpinner(sDXWrapper, vDXWrapperConfig);
-        loadGraphicsDriverSpinner(sGraphicsDriver, sDXWrapper, isEditMode() ? container.getGraphicsDriver() : Container.DEFAULT_GRAPHICS_DRIVER,
-            isEditMode() ? container.getDXWrapper() : Container.DEFAULT_DXWRAPPER);
+        String defaultGraphicsDriver = isEditMode() ? container.getGraphicsDriver() : GPUInformation.getRecommendedGraphicsDriver(context);
+        String defaultDXWrapper = isEditMode() ? container.getDXWrapper() : GPUInformation.getRecommendedDXWrapper(context);
+        loadGraphicsDriverSpinner(sGraphicsDriver, sDXWrapper, defaultGraphicsDriver, defaultDXWrapper);
 
         view.findViewById(R.id.BTHelpDXWrapper).setOnClickListener((v) -> AppUtils.showHelpBox(context, v, R.string.dxwrapper_help_content));
 

--- a/app/src/main/java/com/winlator/core/GPUInformation.java
+++ b/app/src/main/java/com/winlator/core/GPUInformation.java
@@ -109,4 +109,27 @@ public abstract class GPUInformation {
     public static boolean isAdreno6xx(Context context) {
         return getRenderer(context).toLowerCase(Locale.ENGLISH).matches(".*adreno[^6]+6[0-9]{2}.*");
     }
+
+    public static boolean isAdreno(Context context) {
+        return getRenderer(context).toLowerCase(Locale.ENGLISH).contains("adreno");
+    }
+
+    public static boolean isMali(Context context) {
+        return getRenderer(context).toLowerCase(Locale.ENGLISH).contains("mali");
+    }
+
+    public static boolean isPowerVR(Context context) {
+        String renderer = getRenderer(context).toLowerCase(Locale.ENGLISH);
+        return renderer.contains("powervr") || renderer.contains("sgx") || renderer.contains("rogue");
+    }
+
+    public static String getRecommendedGraphicsDriver(Context context) {
+        if (isAdreno(context)) return "turnip";
+        return "virgl";
+    }
+
+    public static String getRecommendedDXWrapper(Context context) {
+        if (isAdreno(context)) return "dxvk";
+        return "wined3d";
+    }
 }


### PR DESCRIPTION
## Summary

- Detect the device GPU at container creation time and default to the optimal graphics driver
- Adreno GPUs: default to **Turnip + DXVK** (best performance path)
- Mali / PowerVR / other GPUs: default to **VirGL + WineD3D** (compatible path)

## Problem

Currently, all new containers default to `turnip` regardless of the actual GPU hardware. This causes immediate black screens or crashes on **non-Adreno devices** (Samsung Exynos with Mali, MediaTek Dimensity with Mali, etc.). Users have to manually discover they need to switch to VirGL, which is unintuitive and the most common source of "nothing works" first-run reports.

Related issues: #145, #550, #586, #608, #1127

## Changes

**`GPUInformation.java`** -- Added GPU family detection methods:
- `isAdreno()` / `isMali()` / `isPowerVR()` -- detect GPU family from GL_RENDERER string
- `getRecommendedGraphicsDriver()` -- returns `"turnip"` for Adreno, `"virgl"` for others
- `getRecommendedDXWrapper()` -- returns `"dxvk"` for Adreno, `"wined3d"` for others

**`ContainerDetailFragment.java`** -- When creating a new container (not editing existing), use the detected GPU's recommended driver/wrapper instead of the hardcoded `turnip`/`dxvk` defaults.

## Impact

- **Zero behavior change** for Adreno users (still defaults to turnip)
- **Immediate fix** for Mali/PowerVR users who currently get broken first-run experience
- Existing containers are not affected (only applies when creating new containers)

## Test plan

- [ ] Create new container on Adreno device -- should default to Turnip + DXVK
- [ ] Create new container on Mali device -- should default to VirGL + WineD3D  
- [ ] Edit existing container -- should show current saved values, not auto-detected
- [ ] Override auto-detected defaults manually -- should work as before