### PR TITLE
Fix TU_DEBUG persistent mutation and EnvVars parsing crash

### DIFF
--- a/app/src/main/java/com/winlator/XServerDisplayActivity.java
+++ b/app/src/main/java/com/winlator/XServerDisplayActivity.java
@@ -616,10 +616,10 @@ public class XServerDisplayActivity extends AppCompatActivity implements Navigat
             envVars.put("vblank_mode", "0");
 
             if (!GPUInformation.isAdreno6xx(this)) {
-                EnvVars userEnvVars = new EnvVars(container.getEnvVars());
-                String tuDebug = userEnvVars.get("TU_DEBUG");
-                if (!tuDebug.contains("sysmem")) userEnvVars.put("TU_DEBUG", (!tuDebug.isEmpty() ? tuDebug+"," : "")+"sysmem");
-                container.setEnvVars(userEnvVars.toString());
+                String tuDebug = new EnvVars(container.getEnvVars()).get("TU_DEBUG");
+                if (!tuDebug.contains("sysmem")) {
+                    envVars.put("TU_DEBUG", (!tuDebug.isEmpty() ? tuDebug + "," : "") + "sysmem");
+                }
             }
 
             boolean useDRI3 = preferences.getBoolean("use_dri3", true);

--- a/app/src/main/java/com/winlator/core/EnvVars.java
+++ b/app/src/main/java/com/winlator/core/EnvVars.java
@@ -23,8 +23,9 @@ public class EnvVars implements Iterable<String> {
         String[] parts = values.split(" ");
         for (String part : parts) {
             int index = part.indexOf("=");
+            if (index <= 0) continue;
             String name = part.substring(0, index);
-            String value = part.substring(index+1);
+            String value = part.substring(index + 1);
             data.put(name, value);
         }
     }


### PR DESCRIPTION
## Summary

- **Fix TU_DEBUG persistent mutation**: On non-Adreno 6xx devices, the `sysmem` flag injection was calling `container.setEnvVars()` which permanently mutated the user's saved container configuration on every launch. The default `TU_DEBUG=noconform` would accumulate `,sysmem` in the saved config. Now applies the `sysmem` flag to the runtime `envVars` object only, leaving the container's saved configuration untouched.

- **Fix EnvVars.putAll() crash**: `putAll(String)` would throw `StringIndexOutOfBoundsException` when encountering malformed entries (trailing spaces, entries without `=`), since `indexOf("=")` returns -1 which causes `substring(0, -1)` to crash. Added a guard to skip entries where the `=` separator is missing or at position 0.

## Test plan

- [ ] Launch a container on a non-Adreno 6xx device, verify `TU_DEBUG` includes `sysmem` at runtime
- [ ] Close and re-open the container settings, verify the saved `TU_DEBUG` value is still the user's original (e.g., `noconform`), not `noconform,sysmem`
- [ ] Test with a container env var string containing trailing spaces — verify no crash