### PR TITLE
Add game profile database for per-game optimal settings

### DIFF
--- a/app/src/main/assets/game_profiles.json
+++ b/app/src/main/assets/game_profiles.json
@@ -1,0 +1,223 @@
+[
+  {
+    "name": "Elden Ring",
+    "exe": "eldenring.exe",
+    "screenSize": "1280x720",
+    "graphicsDriver": "turnip",
+    "dxwrapper": "dxvk",
+    "box64Preset": "COMPATIBILITY",
+    "envVars": "DXVK_ASYNC=1 MESA_VK_WSI_PRESENT_MODE=mailbox",
+    "forceFullscreen": "1",
+    "rating": "playable"
+  },
+  {
+    "name": "The Witcher 3",
+    "exe": "witcher3.exe",
+    "screenSize": "1280x720",
+    "graphicsDriver": "turnip",
+    "dxwrapper": "dxvk",
+    "box64Preset": "COMPATIBILITY",
+    "envVars": "DXVK_ASYNC=1 MESA_VK_WSI_PRESENT_MODE=mailbox",
+    "forceFullscreen": "1",
+    "rating": "playable"
+  },
+  {
+    "name": "Skyrim Special Edition",
+    "exe": "SkyrimSE.exe",
+    "screenSize": "1280x720",
+    "graphicsDriver": "turnip",
+    "dxwrapper": "dxvk",
+    "box64Preset": "INTERMEDIATE",
+    "envVars": "DXVK_ASYNC=1",
+    "forceFullscreen": "1",
+    "rating": "playable"
+  },
+  {
+    "name": "Fallout 4",
+    "exe": "Fallout4.exe",
+    "screenSize": "1280x720",
+    "graphicsDriver": "turnip",
+    "dxwrapper": "dxvk",
+    "box64Preset": "COMPATIBILITY",
+    "envVars": "DXVK_ASYNC=1 WINEDLLOVERRIDES=xaudio2_7=n,b",
+    "forceFullscreen": "1",
+    "rating": "playable"
+  },
+  {
+    "name": "Grand Theft Auto V",
+    "exe": "GTA5.exe",
+    "screenSize": "1280x720",
+    "graphicsDriver": "turnip",
+    "dxwrapper": "dxvk",
+    "box64Preset": "INTERMEDIATE",
+    "envVars": "DXVK_ASYNC=1 STAGING_SHARED_MEMORY=1",
+    "forceFullscreen": "1",
+    "rating": "playable"
+  },
+  {
+    "name": "Dark Souls III",
+    "exe": "DarkSoulsIII.exe",
+    "screenSize": "1280x720",
+    "graphicsDriver": "turnip",
+    "dxwrapper": "dxvk",
+    "box64Preset": "COMPATIBILITY",
+    "envVars": "DXVK_ASYNC=1",
+    "forceFullscreen": "1",
+    "rating": "playable"
+  },
+  {
+    "name": "Sekiro",
+    "exe": "sekiro.exe",
+    "screenSize": "1280x720",
+    "graphicsDriver": "turnip",
+    "dxwrapper": "dxvk",
+    "box64Preset": "COMPATIBILITY",
+    "envVars": "DXVK_ASYNC=1",
+    "forceFullscreen": "1",
+    "rating": "playable"
+  },
+  {
+    "name": "Hollow Knight",
+    "exe": "hollow_knight.exe",
+    "screenSize": "1280x720",
+    "graphicsDriver": "turnip",
+    "dxwrapper": "dxvk",
+    "box64Preset": "PERFORMANCE",
+    "envVars": "",
+    "forceFullscreen": "1",
+    "rating": "playable"
+  },
+  {
+    "name": "Stardew Valley",
+    "exe": "Stardew Valley.exe",
+    "screenSize": "1280x720",
+    "graphicsDriver": "turnip",
+    "dxwrapper": "wined3d",
+    "box64Preset": "PERFORMANCE",
+    "envVars": "",
+    "forceFullscreen": "0",
+    "rating": "playable"
+  },
+  {
+    "name": "Cuphead",
+    "exe": "Cuphead.exe",
+    "screenSize": "1280x720",
+    "graphicsDriver": "turnip",
+    "dxwrapper": "dxvk",
+    "box64Preset": "PERFORMANCE",
+    "envVars": "",
+    "forceFullscreen": "1",
+    "rating": "playable"
+  },
+  {
+    "name": "Resident Evil 4 (2005)",
+    "exe": "bio4.exe",
+    "screenSize": "1280x720",
+    "graphicsDriver": "turnip",
+    "dxwrapper": "dxvk",
+    "box64Preset": "INTERMEDIATE",
+    "envVars": "DXVK_ASYNC=1",
+    "forceFullscreen": "1",
+    "rating": "playable"
+  },
+  {
+    "name": "Need for Speed Most Wanted (2005)",
+    "exe": "speed.exe",
+    "screenSize": "1280x720",
+    "graphicsDriver": "turnip",
+    "dxwrapper": "wined3d",
+    "box64Preset": "PERFORMANCE",
+    "envVars": "",
+    "forceFullscreen": "1",
+    "rating": "playable"
+  },
+  {
+    "name": "Counter-Strike: Global Offensive",
+    "exe": "csgo.exe",
+    "screenSize": "1280x720",
+    "graphicsDriver": "turnip",
+    "dxwrapper": "dxvk",
+    "box64Preset": "INTERMEDIATE",
+    "envVars": "DXVK_ASYNC=1",
+    "forceFullscreen": "1",
+    "execArgs": "-nojoy -novid",
+    "rating": "playable"
+  },
+  {
+    "name": "Red Dead Redemption 2",
+    "exe": "RDR2.exe",
+    "screenSize": "1280x720",
+    "graphicsDriver": "turnip",
+    "dxwrapper": "dxvk",
+    "box64Preset": "COMPATIBILITY",
+    "envVars": "DXVK_ASYNC=1 STAGING_SHARED_MEMORY=1",
+    "forceFullscreen": "1",
+    "rating": "runs"
+  },
+  {
+    "name": "Cyberpunk 2077",
+    "exe": "Cyberpunk2077.exe",
+    "screenSize": "1280x720",
+    "graphicsDriver": "turnip",
+    "dxwrapper": "dxvk",
+    "box64Preset": "COMPATIBILITY",
+    "envVars": "DXVK_ASYNC=1 WINE_FULLSCREEN_FSR=1",
+    "forceFullscreen": "1",
+    "rating": "runs"
+  },
+  {
+    "name": "Devil May Cry 5",
+    "exe": "DevilMayCry5.exe",
+    "screenSize": "1280x720",
+    "graphicsDriver": "turnip",
+    "dxwrapper": "dxvk",
+    "box64Preset": "INTERMEDIATE",
+    "envVars": "DXVK_ASYNC=1",
+    "forceFullscreen": "1",
+    "rating": "playable"
+  },
+  {
+    "name": "Metal Gear Solid V: The Phantom Pain",
+    "exe": "mgsvtpp.exe",
+    "screenSize": "1280x720",
+    "graphicsDriver": "turnip",
+    "dxwrapper": "dxvk",
+    "box64Preset": "INTERMEDIATE",
+    "envVars": "DXVK_ASYNC=1",
+    "forceFullscreen": "1",
+    "rating": "playable"
+  },
+  {
+    "name": "Undertale",
+    "exe": "UNDERTALE.exe",
+    "screenSize": "640x480",
+    "graphicsDriver": "turnip",
+    "dxwrapper": "wined3d",
+    "box64Preset": "PERFORMANCE",
+    "envVars": "",
+    "forceFullscreen": "0",
+    "rating": "playable"
+  },
+  {
+    "name": "Terraria",
+    "exe": "Terraria.exe",
+    "screenSize": "1280x720",
+    "graphicsDriver": "turnip",
+    "dxwrapper": "dxvk",
+    "box64Preset": "PERFORMANCE",
+    "envVars": "",
+    "forceFullscreen": "0",
+    "rating": "playable"
+  },
+  {
+    "name": "Celeste",
+    "exe": "Celeste.exe",
+    "screenSize": "1280x720",
+    "graphicsDriver": "turnip",
+    "dxwrapper": "dxvk",
+    "box64Preset": "PERFORMANCE",
+    "envVars": "",
+    "forceFullscreen": "1",
+    "rating": "playable"
+  }
+]

--- a/app/src/main/java/com/winlator/container/GameProfile.java
+++ b/app/src/main/java/com/winlator/container/GameProfile.java
@@ -1,0 +1,78 @@
+package com.winlator.container;
+
+import android.content.Context;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+public class GameProfile {
+    public final String name;
+    public final String exe;
+    public final String screenSize;
+    public final String graphicsDriver;
+    public final String dxwrapper;
+    public final String box64Preset;
+    public final String envVars;
+    public final String forceFullscreen;
+    public final String execArgs;
+    public final String rating;
+
+    public GameProfile(JSONObject json) throws JSONException {
+        this.name = json.getString("name");
+        this.exe = json.getString("exe");
+        this.screenSize = json.optString("screenSize", Container.DEFAULT_SCREEN_SIZE);
+        this.graphicsDriver = json.optString("graphicsDriver", Container.DEFAULT_GRAPHICS_DRIVER);
+        this.dxwrapper = json.optString("dxwrapper", Container.DEFAULT_DXWRAPPER);
+        this.box64Preset = json.optString("box64Preset", "COMPATIBILITY");
+        this.envVars = json.optString("envVars", "");
+        this.forceFullscreen = json.optString("forceFullscreen", "0");
+        this.execArgs = json.optString("execArgs", "");
+        this.rating = json.optString("rating", "unknown");
+    }
+
+    public void applyToShortcut(Shortcut shortcut) {
+        shortcut.putExtra("screenSize", screenSize);
+        shortcut.putExtra("graphicsDriver", graphicsDriver);
+        shortcut.putExtra("dxwrapper", dxwrapper);
+        shortcut.putExtra("box64Preset", box64Preset);
+        if (!envVars.isEmpty()) shortcut.putExtra("envVars", envVars);
+        if (forceFullscreen.equals("1")) shortcut.putExtra("forceFullscreen", "1");
+        if (!execArgs.isEmpty()) shortcut.putExtra("execArgs", execArgs);
+    }
+
+    public static List<GameProfile> loadAll(Context context) {
+        List<GameProfile> profiles = new ArrayList<>();
+        try {
+            InputStream is = context.getAssets().open("game_profiles.json");
+            byte[] buffer = new byte[is.available()];
+            is.read(buffer);
+            is.close();
+            JSONArray array = new JSONArray(new String(buffer));
+            for (int i = 0; i < array.length(); i++) {
+                profiles.add(new GameProfile(array.getJSONObject(i)));
+            }
+        }
+        catch (Exception e) {}
+        return profiles;
+    }
+
+    public static GameProfile findByExe(Context context, String exePath) {
+        if (exePath == null || exePath.isEmpty()) return null;
+        String exeName = exePath.contains("\\") ? exePath.substring(exePath.lastIndexOf("\\") + 1) : exePath;
+        exeName = exeName.contains("/") ? exeName.substring(exeName.lastIndexOf("/") + 1) : exeName;
+        for (GameProfile profile : loadAll(context)) {
+            if (profile.exe.equalsIgnoreCase(exeName)) return profile;
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/app/src/main/java/com/winlator/contentdialog/ShortcutSettingsDialog.java
+++ b/app/src/main/java/com/winlator/contentdialog/ShortcutSettingsDialog.java
@@ -1,5 +1,6 @@
 package com.winlator.contentdialog;
 
+import android.app.AlertDialog;
 import android.content.Context;
 import android.view.View;
 import android.widget.ArrayAdapter;
@@ -8,11 +9,13 @@ import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.PopupMenu;
 import android.widget.Spinner;
+import android.widget.Toast;
 
 import com.winlator.ContainerDetailFragment;
 import com.winlator.R;
 import com.winlator.ShortcutsFragment;
 import com.winlator.box86_64.Box86_64PresetManager;
+import com.winlator.container.GameProfile;
 import com.winlator.container.Shortcut;
 import com.winlator.core.AppUtils;
 import com.winlator.core.EnvVars;
@@ -24,6 +27,7 @@ import com.winlator.winhandler.WinHandler;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.List;
 
 public class ShortcutSettingsDialog extends ContentDialog {
     private final ShortcutsFragment fragment;
@@ -86,6 +90,26 @@ public class ShortcutSettingsDialog extends ContentDialog {
 
         ContainerDetailFragment.createWinComponentsTab(getContentView(), shortcut.getExtra("wincomponents", shortcut.container.getWinComponents()));
         final EnvVarsView envVarsView = createEnvVarsTab();
+
+        findViewById(R.id.BTLoadGameProfile).setOnClickListener((v) -> {
+            final List<GameProfile> gameProfiles = GameProfile.loadAll(context);
+            if (gameProfiles.isEmpty()) return;
+            String[] names = new String[gameProfiles.size()];
+            for (int i = 0; i < gameProfiles.size(); i++) names[i] = gameProfiles.get(i).name;
+            new AlertDialog.Builder(context)
+                .setTitle(R.string.select_game_profile)
+                .setItems(names, (dialog, which) -> {
+                    GameProfile profile = gameProfiles.get(which);
+                    ContainerDetailFragment.loadScreenSizeSpinner(getContentView(), profile.screenSize);
+                    ContainerDetailFragment.loadGraphicsDriverSpinner(sGraphicsDriver, sDXWrapper, profile.graphicsDriver, profile.dxwrapper);
+                    Box86_64PresetManager.loadSpinner("box64", sBox64Preset, profile.box64Preset);
+                    cbForceFullscreen.setChecked(profile.forceFullscreen.equals("1"));
+                    if (!profile.execArgs.isEmpty()) etExecArgs.setText(profile.execArgs);
+                    if (!profile.envVars.isEmpty()) envVarsView.setEnvVars(new EnvVars(profile.envVars));
+                    Toast.makeText(context, context.getString(R.string.game_profile_applied, profile.name), Toast.LENGTH_SHORT).show();
+                })
+                .show();
+        });
 
         AppUtils.setupTabLayout(getContentView(), R.id.TabLayout, R.id.LLTabWinComponents, R.id.LLTabEnvVars, R.id.LLTabAdvanced);
 

--- a/app/src/main/res/layout/shortcut_settings_dialog.xml
+++ b/app/src/main/res/layout/shortcut_settings_dialog.xml
@@ -21,6 +21,14 @@
             android:id="@+id/ETName"
             android:inputType="textCapSentences" />
 
+        <Button
+            style="@style/ButtonNeutral"
+            android:id="@+id/BTLoadGameProfile"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="4dp"
+            android:text="@string/load_game_profile" />
+
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -225,4 +225,7 @@
     <string name="msg_warning_install_wine">Warning: Installing a new version of Wine is recommended for testing purposes only.</string>
     <string name="startup_selection">Startup Selection</string>
     <string name="wine_debug_channel">Wine Debug Channel</string>
+    <string name="load_game_profile">Load Game Profile</string>
+    <string name="select_game_profile">Select Game Profile</string>
+    <string name="game_profile_applied">Game profile applied: %s</string>
 </resources>


### PR DESCRIPTION
## Summary

Adds a built-in game profile system that lets users apply known-good settings for popular games with one tap, eliminating manual per-shortcut configuration.

- **"Load Game Profile" button** in the shortcut settings dialog opens a picker with 20 curated game profiles
- Selecting a profile auto-populates: screen size, graphics driver, DX wrapper, Box64 preset, env vars, exec args, and force fullscreen
- Follows existing codebase patterns (Box86_64Preset for data model, InputControlsManager for asset-loaded profiles)

### Included game profiles (20 games):
Elden Ring, The Witcher 3, Skyrim SE, Fallout 4, GTA V, Dark Souls III, Sekiro, Hollow Knight, Stardew Valley, Cuphead, RE4, NFS Most Wanted, CS:GO, RDR2, Cyberpunk 2077, DMC5, MGSV, Undertale, Terraria, Celeste

### New files:
- `assets/game_profiles.json` — Profile database (easily extensible)
- `container/GameProfile.java` — Data class with `loadAll()`, `findByExe()`, and `applyToShortcut()` methods

### Architecture:
The profile database is a simple JSON asset file, making it easy for the community to contribute new profiles via PRs. The `GameProfile.findByExe()` method also enables future auto-detection of games by executable name.

## Test plan

- [ ] Open shortcut settings for any game → verify "Load Game Profile" button appears
- [ ] Tap "Load Game Profile" → verify picker dialog shows all 20 games
- [ ] Select a profile → verify all settings fields update (screen size, graphics driver, DX wrapper, Box64 preset, env vars, force fullscreen)
- [ ] Confirm settings → verify profile settings are saved to the shortcut
- [ ] Launch the game → verify applied settings take effect at runtime