### PR TITLE
Add crash diagnostics dialog with process output capture

### DIFF
--- a/app/src/main/java/com/winlator/XServerDisplayActivity.java
+++ b/app/src/main/java/com/winlator/XServerDisplayActivity.java
@@ -346,6 +346,43 @@ public class XServerDisplayActivity extends AppCompatActivity implements Navigat
         AppUtils.restartApplication(this);
     }
 
+    private void showCrashDialog(int exitCode) {
+        String signalName = getSignalName(exitCode);
+        String exitInfo = "Exit code: " + exitCode + (signalName != null ? " (" + signalName + ")" : "");
+
+        ArrayList<String> logLines = ProcessHelper.getCrashLogSnapshot();
+        StringBuilder logText = new StringBuilder();
+        logText.append(exitInfo).append("\n\n");
+        if (logLines.isEmpty()) {
+            logText.append("No debug output captured.\nEnable Wine debug or Box86/64 logs in Settings for more detail.");
+        } else {
+            logText.append("Last ").append(logLines.size()).append(" lines of output:\n\n");
+            for (String line : logLines) logText.append(line).append("\n");
+        }
+
+        ContentDialog dialog = new ContentDialog(this);
+        dialog.setTitle(getString(R.string.process_crashed));
+        dialog.setCancelable(false);
+        dialog.setMessage(logText.toString());
+        dialog.setOnConfirmCallback(this::exit);
+        dialog.show();
+    }
+
+    private static String getSignalName(int exitCode) {
+        if (exitCode < 128) return null;
+        switch (exitCode - 128) {
+            case 4: return "Illegal instruction";
+            case 6: return "Aborted";
+            case 7: return "Bus error";
+            case 8: return "Floating point exception";
+            case 9: return "Killed";
+            case 11: return "Segmentation fault";
+            case 13: return "Broken pipe";
+            case 15: return "Terminated";
+            default: return "Signal " + (exitCode - 128);
+        }
+    }
+
     private void setupWineSystemFiles() {
         String appVersion = String.valueOf(AppUtils.getVersionCode(this));
         String imgVersion = String.valueOf(imageFs.getVersion());
@@ -449,7 +486,13 @@ public class XServerDisplayActivity extends AppCompatActivity implements Navigat
         }
 
         guestProgramLauncherComponent.setEnvVars(envVars);
-        guestProgramLauncherComponent.setTerminationCallback((status) -> exit());
+        guestProgramLauncherComponent.setTerminationCallback((status) -> {
+            if (status != 0) {
+                runOnUiThread(() -> showCrashDialog(status));
+            } else {
+                exit();
+            }
+        });
         environment.addComponent(guestProgramLauncherComponent);
 
         if (isGenerateWineprefix()) generateWineprefix();

--- a/app/src/main/java/com/winlator/core/ProcessHelper.java
+++ b/app/src/main/java/com/winlator/core/ProcessHelper.java
@@ -16,6 +16,8 @@ public abstract class ProcessHelper {
     private static final ArrayList<Callback<String>> debugCallbacks = new ArrayList<>();
     private static final byte SIGCONT = 18;
     private static final byte SIGSTOP = 19;
+    private static final int CRASH_LOG_BUFFER_SIZE = 200;
+    private static final ArrayList<String> crashLogBuffer = new ArrayList<>();
 
     public static void suspendProcess(int pid) {
         Process.sendSignal(pid, SIGSTOP);
@@ -46,10 +48,8 @@ public abstract class ProcessHelper {
             pid = pidField.getInt(process);
             pidField.setAccessible(false);
 
-            if (!debugCallbacks.isEmpty()) {
-                createDebugThread(process.getInputStream());
-                createDebugThread(process.getErrorStream());
-            }
+            createDebugThread(process.getInputStream());
+            createDebugThread(process.getErrorStream());
 
             if (terminationCallback != null) createWaitForThread(process, terminationCallback);
         }
@@ -63,6 +63,10 @@ public abstract class ProcessHelper {
                 String line;
                 while ((line = reader.readLine()) != null) {
                     if (PRINT_DEBUG) System.out.println(line);
+                    synchronized (crashLogBuffer) {
+                        crashLogBuffer.add(line);
+                        while (crashLogBuffer.size() > CRASH_LOG_BUFFER_SIZE) crashLogBuffer.remove(0);
+                    }
                     synchronized (debugCallbacks) {
                         if (!debugCallbacks.isEmpty()) {
                             for (Callback<String> callback : debugCallbacks) callback.call(line);
@@ -99,6 +103,18 @@ public abstract class ProcessHelper {
     public static void removeDebugCallback(Callback<String> callback) {
         synchronized (debugCallbacks) {
             debugCallbacks.remove(callback);
+        }
+    }
+
+    public static ArrayList<String> getCrashLogSnapshot() {
+        synchronized (crashLogBuffer) {
+            return new ArrayList<>(crashLogBuffer);
+        }
+    }
+
+    public static void clearCrashLog() {
+        synchronized (crashLogBuffer) {
+            crashLogBuffer.clear();
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -225,4 +225,5 @@
     <string name="msg_warning_install_wine">Warning: Installing a new version of Wine is recommended for testing purposes only.</string>
     <string name="startup_selection">Startup Selection</string>
     <string name="wine_debug_channel">Wine Debug Channel</string>
+    <string name="process_crashed">Process Crashed</string>
 </resources>


### PR DESCRIPTION
## Summary

When Wine/Box64 crashes, users currently see nothing -- the app silently restarts to the main screen. This makes debugging impossible without manually enabling Wine debug logs and trying to reproduce.

This PR adds:

- **Always-on output capture**: `ProcessHelper` now captures the last 200 lines of stdout/stderr in a ring buffer, regardless of whether debug logging is enabled. Minimal overhead (just appending strings to an ArrayList).

- **Crash dialog**: When the process exits with a non-zero status (crash), a dialog shows:
  - The exit code and human-readable signal name (e.g., "Exit code: 139 (Segmentation fault)")
  - The last 200 lines of process output
  - An OK button to proceed with the normal restart

- **Graceful exits** (status == 0) continue to work exactly as before -- silent restart.

### Signal name mapping:
| Code | Signal | Name |
|------|--------|------|
| 132 | SIGILL | Illegal instruction |
| 134 | SIGABRT | Aborted |
| 135 | SIGBUS | Bus error |
| 137 | SIGKILL | Killed |
| 139 | SIGSEGV | Segmentation fault |
| 143 | SIGTERM | Terminated |

## Test plan

- [ ] Run a game that is known to crash → verify crash dialog appears with exit code and output
- [ ] Run a game that exits gracefully → verify normal silent restart (no dialog)
- [ ] Verify the crash dialog shows useful output lines (Wine errors, Box64 messages)
- [ ] Enable Wine debug logs, trigger crash → verify full debug output appears in the dialog