### PR TITLE
Add container config export/import

### DIFF
--- a/app/src/main/java/com/winlator/ContainersFragment.java
+++ b/app/src/main/java/com/winlator/ContainersFragment.java
@@ -29,9 +29,14 @@ import com.winlator.container.Container;
 import com.winlator.container.ContainerManager;
 import com.winlator.contentdialog.ContentDialog;
 import com.winlator.contentdialog.StorageInfoDialog;
+import com.winlator.core.AppUtils;
+import com.winlator.core.FileUtils;
 import com.winlator.core.PreloaderDialog;
 import com.winlator.xenvironment.ImageFs;
 
+import org.json.JSONObject;
+
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -87,6 +92,31 @@ public class ContainersFragment extends Fragment {
                 .addToBackStack(null)
                 .replace(R.id.FLFragmentContainer, new ContainerDetailFragment())
                 .commit();
+            return true;
+        }
+        else if (menuItem.getItemId() == R.id.containers_menu_import) {
+            ((MainActivity)getActivity()).setOpenFileCallback((uri) -> {
+                try {
+                    String content = FileUtils.readString(getContext(), uri);
+                    JSONObject data = new JSONObject(content);
+                    preloaderDialog.show(R.string.creating_container);
+                    manager.createContainerAsync(data, (container) -> {
+                        preloaderDialog.close();
+                        if (container != null) {
+                            loadContainersList();
+                        } else {
+                            AppUtils.showToast(getContext(), R.string.unable_to_import_config);
+                        }
+                    });
+                }
+                catch (Exception e) {
+                    AppUtils.showToast(getContext(), R.string.unable_to_import_config);
+                }
+            });
+            Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+            intent.addCategory(Intent.CATEGORY_OPENABLE);
+            intent.setType("*/*");
+            getActivity().startActivityForResult(intent, MainActivity.OPEN_FILE_REQUEST_CODE);
             return true;
         }
         else return super.onOptionsItemSelected(menuItem);
@@ -162,6 +192,13 @@ public class ContainersFragment extends Fragment {
                             });
                         });
                         break;
+                    case R.id.container_export: {
+                        File exportedFile = manager.exportContainerConfig(container);
+                        if (exportedFile != null) {
+                            AppUtils.showToast(context, context.getString(R.string.config_exported_to, exportedFile.getName()));
+                        }
+                        break;
+                    }
                     case R.id.container_remove:
                         ContentDialog.confirm(getContext(), R.string.do_you_want_to_remove_this_container, () -> {
                             preloaderDialog.show(R.string.removing_container);

--- a/app/src/main/java/com/winlator/container/ContainerManager.java
+++ b/app/src/main/java/com/winlator/container/ContainerManager.java
@@ -15,6 +15,9 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import android.media.MediaScannerConnection;
+import android.os.Environment;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -224,6 +227,26 @@ public class ContainerManager {
             String suffix = wineInfo.fullVersion()+"-"+wineInfo.getArch();
             File file = new File(installedWineDir, "container-pattern-"+suffix+".tzst");
             return TarCompressorUtils.extract(TarCompressorUtils.Type.ZSTD, file, containerDir, onExtractFileListener);
+        }
+    }
+
+    public File exportContainerConfig(Container container) {
+        try {
+            File downloadsDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
+            File destDir = new File(downloadsDir, "Winlator");
+            if (!destDir.exists()) destDir.mkdirs();
+            File destFile = new File(destDir, container.getName() + ".wcc");
+
+            JSONObject data = new JSONObject(FileUtils.readString(container.getConfigFile()));
+            data.remove("id");
+            data.remove("cpuList");
+            data.remove("cpuListWoW64");
+            FileUtils.writeString(destFile, data.toString());
+            MediaScannerConnection.scanFile(context, new String[]{destFile.getAbsolutePath()}, null, null);
+            return destFile;
+        }
+        catch (JSONException e) {
+            return null;
         }
     }
 }

--- a/app/src/main/res/menu/container_popup_menu.xml
+++ b/app/src/main/res/menu/container_popup_menu.xml
@@ -3,6 +3,7 @@
     <item android:id="@+id/container_run" android:title="@string/run" android:icon="@drawable/icon_popup_menu_run" android:iconTint="@color/colorAccent" />
     <item android:id="@+id/container_edit" android:title="@string/edit" android:icon="@drawable/icon_popup_menu_edit" android:iconTint="@color/colorAccent" />
     <item android:id="@+id/container_duplicate" android:title="@string/duplicate" android:icon="@drawable/icon_popup_menu_duplicate" android:iconTint="@color/colorAccent" />
+    <item android:id="@+id/container_export" android:title="@string/export_config" android:icon="@drawable/icon_popup_menu_info" android:iconTint="@color/colorAccent" />
     <item android:id="@+id/container_remove" android:title="@string/remove" android:icon="@drawable/icon_popup_menu_remove" android:iconTint="@color/colorAccent" />
     <item android:id="@+id/container_info" android:title="@string/storage_info" android:icon="@drawable/icon_popup_menu_info" android:iconTint="@color/colorAccent" />
 </menu>

--- a/app/src/main/res/menu/containers_menu.xml
+++ b/app/src/main/res/menu/containers_menu.xml
@@ -7,4 +7,9 @@
         android:id="@+id/containers_menu_add"
         android:title="@string/add"
         app:showAsAction="ifRoom" />
+    <item
+        android:icon="@drawable/icon_popup_menu_open"
+        android:id="@+id/containers_menu_import"
+        android:title="@string/import_config"
+        app:showAsAction="ifRoom" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -225,4 +225,8 @@
     <string name="msg_warning_install_wine">Warning: Installing a new version of Wine is recommended for testing purposes only.</string>
     <string name="startup_selection">Startup Selection</string>
     <string name="wine_debug_channel">Wine Debug Channel</string>
+    <string name="export_config">Export Config</string>
+    <string name="import_config">Import Config</string>
+    <string name="config_exported_to">Config exported to %s</string>
+    <string name="unable_to_import_config">Unable to import container config</string>
 </resources>


### PR DESCRIPTION
## Summary

Allows users to share and reuse container configurations by exporting/importing the settings JSON as a `.wcc` (Winlator Container Config) file.

### Export
- New **"Export Config"** option in the container popup menu (between Duplicate and Remove)
- Saves to `Downloads/Winlator/<container-name>.wcc`
- Strips device-specific fields (`id`, `cpuList`, `cpuListWoW64`) that would be invalid on another device
- File is ~1KB and contains all tuning settings (graphics driver, DX wrapper, env vars, box86/64 preset, win components, etc.)

### Import
- New **import button** in the containers toolbar (action bar)
- Opens the system file picker to select a `.wcc` file
- Creates a new container with the imported settings via the existing `createContainerAsync(JSONObject)` pipeline
- The pipeline automatically assigns a new ID, creates the directory, extracts the Wine container pattern, and applies all settings

### Architecture
- Export reuses the existing `.container` JSON format — just reads, strips the ID, and writes
- Import reuses the existing `createContainerAsync(JSONObject)` — zero new container creation logic needed
- Follows the same file picker pattern used by `InputControlsFragment` for profile import

## Test plan

- [ ] Open container popup menu → "Export Config" appears
- [ ] Export a container → `.wcc` file appears in `Downloads/Winlator/`
- [ ] Open `.wcc` file in a text editor → valid JSON with all container settings, no `id` field
- [ ] Tap import button → file picker opens
- [ ] Select the exported `.wcc` file → new container appears with matching settings
- [ ] Verify imported container's settings match the exported container